### PR TITLE
Add support for ST7735 and ST7789 display boards

### DIFF
--- a/src/Cubotino_T_display.py
+++ b/src/Cubotino_T_display.py
@@ -16,9 +16,20 @@
 from Cubotino_T_settings_manager import settings as settings   # custom library managing the settings from<>to the settings files
 from Cubotino_T_pigpiod import pigpiod as pigpiod  # start the pigpiod server
 from PIL import Image, ImageDraw, ImageFont        # classes from PIL for image manipulation
-import ST7735                                      # library for the TFT display with ST7735 driver
 import os.path, pathlib                            # libraries for path management
 
+
+# Dictionary of LCD data, ST7735 display parameters are default for all other conversions.
+#    Colors: <BGR|RGB> What color scheme does the display use
+#    Inverted: <True|False> Are white and black inverted
+#    BaseRotation: <180|270> Sets the default rotation
+#    SPI: <Value 3900000-125000000> Spi bus speed.
+#    FontScale: Scale factor to apply to all fonts.
+LCDdata = { 'st7735': {'Colors': 'BGR', 'Inverted': False, 'BaseRotation': 270, 'SPI': 10000000, 'FontScale': 1.0, },
+            'st7789': {'Colors': 'RGB', 'Inverted': True,  'BaseRotation': 180, 'SPI': 50000000, 'FontScale': 2.0, }
+          }
+default_x = 160                                                           # Default X Resolution for scaling
+default_y = 128                                                           # Default Y Resolution for scaling
 
 class Display:
     display_initialized = False
@@ -29,10 +40,12 @@ class Display:
             
         if not self.display_initialized:
             s = settings.get_settings()                               # settings are retrieved from the settings Class
+            self.disp_type = s['disp_type']                           # Slect Display type st7735 default
             self.disp_width = int(s['disp_width'])                    # display width, in pixels
             self.disp_height = int(s['disp_height'])                  # display height, in pixels
             self.disp_offsetL = int(s['disp_offsetL'])                # Display offset on width, in pixels, Left if negative
             self.disp_offsetT = int(s['disp_offsetT'])                # Display offset on height, in pixels, Top if negative
+            self.disp_flip = s['disp_flip']                           # Display flipped 180degrees
             self.built_by = str(s['built_by'])                        # maker's name to add on the Cubotino logo
             self.built_by_x = int(s['built_by_x'])                    # x coordinate for maker's name on display
             self.built_by_fs = int(s['built_by_fs'])                  # font size for the maker's name on display
@@ -41,21 +54,48 @@ class Display:
         if not self.display_settings:                                 # case display_settings is still False
             print("Error on loading the display parameters at Cubotino_T_display")
             
+        if self.disp_type == 'st7735':                                # Using a ST7735 based display.
+            print('Importing ST7735 Display')
+            from ST7735 import ST7735 as LCD                          # library for the TFT display with ST7735 driver
+        elif self.disp_type == 'st7789':                              # Using a ST7789 based display. 
+            print('Importing ST7789 Display')
+            from ST7789 import ST7789 as LCD                          # library for the TFT display with ST7789 driver
+        else:
+            raise Exception('Invalid Display Type in settings')       # raise exception if display type is wrong
+
+        # Set screen data from table above
+        if self.disp_flip:                                            # Flip the screen upside down if true.
+            self.disp_rotation = LCDdata[self.disp_type]['BaseRotation'] - 180  # LCD Data uses >= 180 for base.
+        else:
+            self.disp_rotation = LCDdata[self.disp_type]['BaseRotation']
+            
+        self.disp_color_invert = LCDdata[self.disp_type]['Inverted']  # Invert white/black
+        self.disp_spi_freq = LCDdata[self.disp_type]['SPI']           # Set SPI Speed
+        self.disp_colors = LCDdata[self.disp_type]['Colors']          # Set BGR or RGB colors
+        self.fontscale = LCDdata[self.disp_type]['FontScale']         # Set BGR or RGB colors
+
+        if self.disp_rotation == 90 or self.disp_rotation == 270:      # Screen width/height is rotated
+            self.Xscale = (self.disp_height / default_x )             # Scale factor is based on 160x128 screen
+            self.Yscale = (self.disp_width / default_y )
+        else:
+            self.Xscale = (self.disp_width / default_x )              # Scale factor is based on 160x128 screen
+            self.Yscale = (self.disp_height / default_y )
+
         if self.display_settings:
-            self.disp = ST7735.ST7735(port=0, cs=0,                   # SPI and Chip Selection                  
-                                dc=27, rst=22, backlight=4,           # GPIO pins used for the SPI, reset and backlight control
-                                width=self.disp_width,     #(AF 132)  # see note above for width and height !!!
-                                height=self.disp_height,   #(AF 162)  # see note above for width and height !!!                         
-                                offset_left=self.disp_offsetL,        # see note above for offset  !!!
-                                offset_top=self.disp_offsetT,         # see note above for offset  !!!
-                                rotation=270,                         # image orientation
-                                invert=False,                         # image invertion,
-                                spi_speed_hz=10000000)                # SPI frequence
+            self.disp = LCD(port=0, cs=0,                             # SPI and Chip Selection
+                            dc=27, rst=22, backlight=4,               # GPIO pins used for the SPI, reset and backlight control
+                            width=self.disp_width,     #(AF 132)      # see note above for width and height !!!
+                            height=self.disp_height,   #(AF 162)      # see note above for width and height !!!
+                            offset_left=self.disp_offsetL,            # see note above for offset  !!!
+                            offset_top=self.disp_offsetT,             # see note above for offset  !!!
+                            rotation=self.disp_rotation,              # image orientation
+                            invert=self.disp_color_invert,            # image invertion,
+                            spi_speed_hz=self.disp_spi_freq)          # SPI frequency
         
             self.disp.set_backlight(0)                                # display backlight is set off
             self.disp_w = self.disp.width                             # display width, retrieved by display setting
             self.disp_h = self.disp.height                            # display height, retrieved by display setting
-            disp_img = Image.new('RGB', (self.disp_w, self.disp_h),color=(0, 0, 0))   # display image generation, full black
+            disp_img = Image.new('RGB', (self.disp_w, self.disp_h),color=self.bgr((0, 0, 0)))   # display image generation, full black
             self.disp.display(disp_img)                               # image is displayed
             if not self.display_initialized:                          # case display_initialized is set False
                 print("\nDisplay initialized\n")                      # feedback is printed to the terminal
@@ -71,13 +111,45 @@ class Display:
         else:                                                         # case the logo file does not exist
             print(f"\nNot found {fname}")                             # feedback is printedto terminal
             print("Cubotino logo image is missed\n")                  # feedback is printedto terminal
-            self.logo = Image.new('RGB', (self.disp_w, self.disp_h), color=(0, 0, 0))  # full black screen as new image
+            self.logo = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))  # full black screen as new image
             logo_text = ImageDraw.Draw(self.logo)                     # image is drawned
-            f1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 26)  # font and size
-            f2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 22)  # font and size
-            logo_text.text((10, 44), "CUBOT", font=f1, fill=(255, 255, 255))  # text, font, white color
-            logo_text.text((112, 48), "ino", font=f2, fill=(255, 255, 255))   # text, font, white color
+            f1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(26))  # font and size
+            f2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(22))  # font and size
+            logo_text.text(self.scale_xy((10, 44)), "CUBOT", font=f1, fill=self.bgr((255, 255, 255)))  # text, font, white color
+            logo_text.text(self.scale_xy((112, 48)), "ino", font=f2, fill=self.bgr((255, 255, 255)))   # text, font, white color
 
+
+
+
+    def bgr(self, c):                             # Function to convert colors for displays that take RGB colors
+        if self.disp_colors == 'RGB':
+            return ( c[2], c[1], c[0] )
+        return c
+
+
+
+
+    def fontsize(self, pt):                       # Change font size based on screen scaling factor
+        return int(pt * self.fontscale)
+
+
+
+
+    def scale_xy( self, coord):                   # Scale (x,y) coordinates based on screen scale
+        scaledx = int( coord[0] * self.Xscale)
+        scaledy = int( coord[1] * self.Yscale)
+        return (scaledx, scaledy)
+
+
+
+
+    def scale_rect( self, coord):                 # Scale (x,y,x1,y1) coordinates based on screen scale
+        scaledx1 = int( coord[0] * self.Xscale)
+        scaledy1 = int( coord[1] * self.Yscale)
+        scaledx2 = int( coord[2] * self.Xscale)
+        scaledy2 = int( coord[3] * self.Yscale)
+        scaled = (scaledx1, scaledy1, scaledx2, scaledy2)
+        return scaled
 
 
 
@@ -90,8 +162,8 @@ class Display:
 
     def clean_display(self):
         """ Cleans the display by settings all pixels to black."""
-        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=(0, 0, 0))  # full black screen as new image
-        self.disp.display(disp_img)                                               # display is shown to display
+        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))  # full black screen as new image
+        self.disp.display(disp_img)                                                         # display is shown to display
 
 
 
@@ -104,12 +176,12 @@ class Display:
             fs1, fs2: font size for text at row1 and row2
             """
         
-        font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", fs1)  # font and size for first text row
-        font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", fs2)  # font and size for second text row
-        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=(0, 0, 0))                 # full black image
+        font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(fs1))  # font and size for first text row
+        font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(fs2))  # font and size for second text row
+        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))                 # full black image
         disp_draw = ImageDraw.Draw(disp_img)                                                     # image is drawned
-        disp_draw.text((x1, y1), r1, font=font1, fill=(255, 255, 255))    # first text row start coordinate, text, font, white color
-        disp_draw.text((x2, y2), r2, font=font2, fill=(255, 255, 255))    # second text row start coordinate, text, font, white color
+        disp_draw.text(self.scale_xy((x1, y1)), r1, font=font1, fill=self.bgr((255, 255, 255)))    # first text row start coordinate, text, font, white color
+        disp_draw.text(self.scale_xy((x2, y2)), r2, font=font2, fill=self.bgr((255, 255, 255)))    # second text row start coordinate, text, font, white color
         self.disp.display(disp_img)                                       # image is plot to the display
         self.disp.set_backlight(1)                                        # display backlight is set on
 
@@ -119,16 +191,16 @@ class Display:
     def display_progress_bar(self, percent, scrambling=False):
         """ Function to print a progress bar on the display."""
         
-        w = self.disp_w                                            # display width, retrieved by display setting
+        w = default_x                                              # display width, retrieved by display setting
         
         # percent value printed as text 
-        fs = 40                 # font size
-        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", fs)     # font and its size
+        fs = 40                 # font size (Scaled in next line)
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(fs))     # font and its size
         text_x = int(w/2 - (fs*len(str(percent))+1)/2)             # x coordinate for the text starting location         
         text_y = 15                                                # y coordinate for the text starting location
-        disp_img = Image.new('RGB', (w, self.disp_h), color=(0, 0, 0)) # full black image
-        disp_draw = ImageDraw.Draw(disp_img)                        # image is drawned
-        disp_draw.text((text_x, text_y), str(percent)+'%', font=font, fill=(255, 255, 255))    # text with percent value
+        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0))) # full black image
+        disp_draw = ImageDraw.Draw(disp_img)                       # image is drawned
+        disp_draw.text(self.scale_xy((text_x, text_y)), str(percent)+'%', font=font, fill=self.bgr((255, 255, 255)))    # text with percent value
         
         # percent value printed as progress bar filling 
         x = 15                  # x coordinate for the bar starting location
@@ -139,13 +211,13 @@ class Display:
         elif scrambling:        # case the robot is scrambling a cube
             barWidth = 18       # width of the bar, in pixels
             fs = 18             # font size
-            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", fs)  # font and its size
-            disp_draw.text((15, 85), 'SCRAMBLING', font=font, fill=(255, 255, 255))                # SCRAMBLING text
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(fs))  # font and its size
+            disp_draw.text(self.scale_xy((15, 85)), 'SCRAMBLING', font=font, fill=self.bgr((255, 255, 255)))                # SCRAMBLING text
             
         barLength = w-2*x-4 #135   # lenght of the bar, in pixels
         filledPixels = int( x+gap +(barLength-2*gap)*percent/100)  # bar filling length, as function of the percent
-        disp_draw.rectangle((x, y, x+barLength, y+barWidth), outline="white", fill=(0,0,0))   # outer bar border
-        disp_draw.rectangle((x+gap, y+gap, filledPixels, y+barWidth-gap), fill=(255,255,255)) # bar filling
+        disp_draw.rectangle(self.scale_rect((x, y, x+barLength, y+barWidth)), outline="white", fill=self.bgr((0,0,0)))   # outer bar border
+        disp_draw.rectangle(self.scale_rect((x+gap, y+gap, filledPixels, y+barWidth-gap)), fill=self.bgr((255,255,255))) # bar filling
         
         self.disp.display(disp_img) # image is plotted to the display
         self.disp.set_backlight(1)  # display backlight is set on
@@ -158,14 +230,14 @@ class Display:
         
         if built_by != '':                                 # case the built_by variable is not empty
             disp_draw = ImageDraw.Draw(self.logo)          # image is plotted to display
-            font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 14)  # font1
-            disp_draw.text((15, 10), "Andrea FAVERO's", font=font1, fill=(0, 0, 255))  # first row text test
+            font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(14))  # font1
+            disp_draw.text(self.scale_xy((15, 10)), "Andrea FAVERO's", font=font1, fill=self.bgr((0, 0, 255)))  # first row text test
             
-            font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 10)  # font1
-            disp_draw.text((60, 85), "Built by", font=font2, fill=(255, 255, 255))    # second row text test
+            font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(10))  # font1
+            disp_draw.text(self.scale_xy((60,85)), "Built by", font=font2, fill=self.bgr((255, 255, 255)))    # second row text test
             
-            font3 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", fs)  # font1
-            disp_draw.text((x, 104), built_by, font=font3, fill=(255, 0, 0))              # third row text test
+            font3 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(fs))  # font1
+            disp_draw.text(self.scale_xy((x, 104)), built_by, font=font3, fill=self.bgr((255, 0, 0)))              # third row text test
         self.disp.display(self.logo)                       # draws the image on the display hardware.
         self.disp.set_backlight(1)                         # display backlight is set on
 
@@ -175,20 +247,20 @@ class Display:
     def show_face(self, side, colours=[]):
         """ Function to print a sketch of the cube face colours."""
         
-        w = self.disp_w                                    # display width, retrieved by display setting
-        h = self.disp_h                                    # display height, retrieved by display setting
+        w = default_x                                      # display width, default size
+        h = default_y                                      # display height, default size
         faces = ('', 'U', 'B', 'D', 'F', 'R', 'L')         # tuple of faces letters
         y_start = 20                                       # y coordinate for face top-left corner
         d = int(h-y_start)/3.8                             # facelet square side
         x_start = w-5-3*d                                  # x coordinate for face top-left corner
         gap = 3                                            # gap beftween the facelets border and facelets coloured part
         
-        font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 17)  # font1
-        font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 70)  # font1
-        disp_img = Image.new('RGB', (w, h), color=(0, 0, 0))  # full black image
+        font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(17))  # font1
+        font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(70))  # font1
+        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))  # full black image
         disp_draw = ImageDraw.Draw(disp_img)               # image is drawned
-        disp_draw.text((12, 25), 'FACE', font=font1, fill=(255, 255, 255))   # first row text test
-        disp_draw.text((9, 40), faces[side], font=font2, fill=(255, 255, 255))   # first row text test
+        disp_draw.text(self.scale_xy((12, 25)), 'FACE', font=font1, fill=self.bgr((255, 255, 255)))   # first row text test
+        disp_draw.text(self.scale_xy((9, 40)), faces[side], font=font2, fill=self.bgr((255, 255, 255)))   # first row text test
         self.disp.set_backlight(1)                         # display backlight is set on
         
         fclt = 0
@@ -196,14 +268,14 @@ class Display:
         for i in range(3):                                 # iteration over rows
             x = x_start                                    # x coordinate value for the first facelet
             for j in range(3):                             # iteration over columns
-                disp_draw.rectangle((x, y, x+d, y+d), outline="white", fill=(0,0,0))   # outer bar border
+                disp_draw.rectangle(self.scale_rect((x, y, x+d, y+d)), outline="white", fill=self.bgr((0,0,0)))   # outer bar border
                 if len(colours)==9:                        # case colour is prodided
-                    disp_draw.rectangle((x+gap, y+gap, x+d-gap-1, y+d-gap-1), colours[fclt]) #colours[fclt]) # bar filling
+                    disp_draw.rectangle(self.scale_rect((x+gap, y+gap, x+d-gap-1, y+d-gap-1)), self.bgr(colours[fclt])) #colours[fclt]) # bar filling
                 x = x+d                                    # x coordinate is increased by square side
                 if j == 2: y = y+d                         # once at the third column the row is incremented
                 fclt+=1
-        
-        self.disp.display(disp_img) # image is plotted to the display
+
+        self.disp.display(disp_img)                        # image is plotted to the display
 
     
     
@@ -242,7 +314,7 @@ class Display:
                         if j == 2: y = y+self.d            # once at the second column the row is incremented
             self.tlc = tuple(tlc)                          # tlc list is converted to tuple
             
-            self.disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=(0, 0, 0))  # full black image
+            self.disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))  # full black image
             self.disp_draw = ImageDraw.Draw(self.disp_img) # image is drawned
             
         
@@ -253,7 +325,7 @@ class Display:
             y = self.tlc[i][1]+self.g                      # y coordinate for the origin-square colored facelet
             dx = x + self.d - self.gg                      # x coordinate for the end-square colored facelet
             dy = y + self.d - self.gg                      # y coordinate for the end-square colored facelet
-            self.disp_draw.rectangle((x, y, dx, dy), (B,G,R))   # cube sketch grid
+            self.disp_draw.rectangle(self.scale_rect((x, y, dx, dy)), self.bgr((B,G,R)))   # cube sketch grid
         
         self.disp.display(self.disp_img)                   # image is drawned
         self.disp.set_backlight(1)                         # display backlight is set on
@@ -269,12 +341,12 @@ class Display:
         
         import time
         
-        w = self.disp_w                                            # display width, retrieved by display setting
-        h = self.disp_h                                            # display height, retrieved by display setting
+        w = default_x                                                     # display width, scaled below
+        h = default_y                                                     # display height, scaled below
         
-        font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 20)  # font1
-        font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 16)  # font2
-        disp_img = Image.new('RGB', (w, h), color=(0, 0, 0))      # full black image
+        font1 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(20))  # font1
+        font2 = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", self.fontsize(16))  # font2
+        disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))      # full black image
         
         self.disp.set_backlight(1)                                        # display backlight is set on
         start = time.time()                                               # time refrence for countdown
@@ -286,17 +358,17 @@ class Display:
             if t_left%2==0:                                               # case the time left is even
                 t_left_str = str(t_left)                                  # string of time left
                 pos = w-40 if t_left>9 else w-35                          # position x for timeout text
-                disp_img = Image.new('RGB', (w, h), color=(0, 0, 0))      # full black image
+                disp_img = Image.new('RGB', (self.disp_w, self.disp_h), color=self.bgr((0, 0, 0)))      # full black image
                 disp_draw = ImageDraw.Draw(disp_img)                      # image is drawned
 
-                disp_draw.rectangle((2, 2, w-4, h-4), outline="white", fill=(0,0,0))    # border 1
-                disp_draw.rectangle((5, 5, w-7, h-7), outline="white", fill=(0,0,0))    # border 2
-                disp_draw.rectangle((8, 8, w-10, h-10), outline="white", fill=(0,0,0))  # border 3
-                disp_draw.rectangle((w-45, h-40, w-14, h-14), outline="blue", fill=(0,0,0)) # border for timeout
+                disp_draw.rectangle(self.scale_rect((2, 2, w-4, h-4)), outline="white", fill=self.bgr((0,0,0)))    # border 1
+                disp_draw.rectangle(self.scale_rect((5, 5, w-7, h-7)), outline="white", fill=self.bgr((0,0,0)))    # border 2
+                disp_draw.rectangle(self.scale_rect((8, 8, w-10, h-10)), outline="white", fill=self.bgr((0,0,0)))  # border 3
+                disp_draw.rectangle(self.scale_rect((w-45, h-40, w-14, h-14)), outline="blue", fill=self.bgr((0,0,0))) # border for timeout
                 
-                disp_draw.text((pos, h-36), t_left_str , font=font2, fill=(0, 0, 255))  # timeout text
-                disp_draw.text((30, 25), 'DISPLAY', font=font1, fill=(255, 255, 255))   # first row text test
-                disp_draw.text((33, 75), 'TEST', font=font1, fill=(255, 255, 255))      # second row text test
+                disp_draw.text(self.scale_xy((pos, h-36)), t_left_str , font=font2, fill=self.bgr((0, 0, 255)))  # timeout text
+                disp_draw.text(self.scale_xy((30, 25)), 'DISPLAY', font=font1, fill=self.bgr((255, 255, 255)))   # first row text test
+                disp_draw.text(self.scale_xy((33, 75)), 'TEST', font=font1, fill=self.bgr((255, 255, 255)))      # second row text test
                 self.disp.display(disp_img)                                             # image is drawned
                 time.sleep(0.1)                                           # little sleeping time   
             else:                                                         # case the time left is odd
@@ -333,14 +405,6 @@ class Display:
         self.clean_display()                                          # display is set to full black
         self.disp.set_backlight(0)                                    # display backlight is set off
         print("Display test2 finished\n")                             # feedback is printed to the terminal
-
-
-
-
-    def get_fname_AF(self, fname, pos):
-        return fname[:-4] + '_AF' + str(pos+1) + '.txt'
-
-
 
 
 

--- a/src/Cubotino_T_display.py
+++ b/src/Cubotino_T_display.py
@@ -26,7 +26,7 @@ import os.path, pathlib                            # libraries for path manageme
 #    SPI: <Value 3900000-125000000> Spi bus speed.
 #    FontScale: Scale factor to apply to all fonts.
 LCDdata = { 'st7735': {'Colors': 'BGR', 'Inverted': False, 'BaseRotation': 270, 'SPI': 10000000, 'FontScale': 1.0, },
-            'st7789': {'Colors': 'RGB', 'Inverted': True,  'BaseRotation': 180, 'SPI': 50000000, 'FontScale': 2.0, }
+            'st7789': {'Colors': 'RGB', 'Inverted': True,  'BaseRotation': 180, 'SPI': 50000000, 'FontScale': 1.8, }
           }
 default_x = 160                                                           # Default X Resolution for scaling
 default_y = 128                                                           # Default Y Resolution for scaling

--- a/src/Cubotino_T_settings_AF1.txt
+++ b/src/Cubotino_T_settings_AF1.txt
@@ -1,9 +1,11 @@
 {
 "frameless_cube": "auto",
+"disp_type": "st7735",
 "disp_width": "130",
 "disp_height": "162",
 "disp_offsetL": "-2",
 "disp_offsetT": "-2",
+"disp_flip": "false",
 "camera_width_res": "640",
 "camera_hight_res": "480",
 "s_mode": "7",

--- a/src/Cubotino_T_settings_AF2.txt
+++ b/src/Cubotino_T_settings_AF2.txt
@@ -1,9 +1,11 @@
 {
 "frameless_cube": "auto",
+"disp_type": "st7735",
 "disp_width": "128",
 "disp_height": "164",
 "disp_offsetL": "0",
 "disp_offsetT": "-4",
+"disp_flip": "false",
 "camera_width_res": "640",
 "camera_hight_res": "480",
 "s_mode": "7",

--- a/src/Cubotino_T_settings_default.txt
+++ b/src/Cubotino_T_settings_default.txt
@@ -1,9 +1,11 @@
 {
 "frameless_cube": "false",
+"disp_type": "st7735",
 "disp_width": "128",
 "disp_height": "160",
 "disp_offsetL": "0",
 "disp_offsetT": "0",
+"disp_flip": "false",
 "camera_width_res": "640",
 "camera_hight_res": "480",
 "s_mode": "7",

--- a/src/Cubotino_T_settings_manager.py
+++ b/src/Cubotino_T_settings_manager.py
@@ -171,6 +171,22 @@ class Settings:
             else:                                                 # case the frameless parameter is not 'false', 'true' or 'auto'
                 print('\n\nAttention: Wrong frameless_cube parameter: It should be "true", "false" or "auto".\n')  # feedback is printed to the terminal
                 frameless_cube = 'auto'                           # cube with/without black frame around the facelets
+
+            if s['disp_type'].lower().strip() == 'st7735':        # Slect Display type st7735 default
+                s['disp_type'] = 'st7735'
+            elif s['disp_type'].lower().strip() == 'st7789':      # Slect Display type st7789
+                s['disp_type'] = 'st7789'
+            else:
+                print('\n\nAttention: Wrong disp_tyep parameter: It should be "st7735" or "st7789."\n')  # feedback is printed to the terminal
+                s['disp_type'] = 'st7735'
+
+            if s['disp_flip'].lower().strip() == 'false':          # Display not rotated.
+                s['disp_flip'] = False
+            elif s['disp_flip'].lower().strip() == 'true':         # Display flipped 180degrees
+                s['disp_flip'] = True
+            else:
+                print('\n\nAttention: Wrong disp_flip parameter: It should be "true" or "false."\n')  # feedback is printed to the terminal
+                s['disp_flip'] = False
             
             s['disp_width'] = int(s['disp_width'])                # display width, in pixels
             s['disp_height'] = int(s['disp_height'])              # display height, in pixels
@@ -465,6 +481,14 @@ class Settings:
         
         if 'fcs_delay' not in s_keys:
             s['fcs_delay']='3'
+            any_change = True
+        
+        if 'disp_type' not in s_keys:
+            s['disp_type'] = 'st7735'
+            any_change = True
+        
+        if 'disp_flip' not in s_keys:
+            s['disp_flip'] = 'false'
             any_change = True
          
         if any_change:


### PR DESCRIPTION
My first ST7735 board came damaged, and the replacement was taking forever so I bought one of these

https://www.waveshare.com/product/displays/lcd-oled/lcd-oled-3/2inch-lcd-module.htm

This pull request add support for both boards through the settings file.   I don't yet have a ST7735 board to test....but should work the same.  Perhaps you can test.

One thing I noticed while running the tests.  The facelet color space is BGR, which meant the display showed the wrong color.  So I converted the values to RGB before showing on the screen.   Not sure if this is something related to my display, or something that was never quite right.

This is a 320x240 resolution display.  Obviously a few more pixels to display, so I added options to change the SPI speed too. below are the settings I'm using with this display

"disp_type": "st7789",
"disp_width": "320",
"disp_height": "240",
"disp_offsetL": "0",
"disp_offsetT": "0",
"disp_rotation": "180",
"disp_color_invert": "true",
"disp_spi_freq": "50000000"

I can post a pcb cover model that fits this screen (Once I get done fitting it)
