### PR TITLE
Remove broken and unneeded imports

### DIFF
--- a/src/Cubotino_T_camera_os10.py
+++ b/src/Cubotino_T_camera_os10.py
@@ -16,12 +16,7 @@
 from Cubotino_T_settings_manager import settings as settings  # settings manager Class
 from picamera.array import PiRGBArray        # Raspberry Pi specific package for the camera, using numpy array
 from picamera import PiCamera                # Raspberry Pi specific package for the camera
-import os.path, pathlib, json                # library for the json parameter parsing for the display
-from getmac import get_mac_address           # library to get the device MAC ddress
-from get_macs_AF import get_macs_AF          # import the get_macs_AF function
-macs_AF = get_macs_AF()                      # mac addresses of AF bots are retrieved
 import time
-import sys
 
 
 class Camera:

--- a/src/Cubotino_T_camera_os11.py
+++ b/src/Cubotino_T_camera_os11.py
@@ -16,10 +16,6 @@
 from Cubotino_T_settings_manager import settings as settings  # settings manager Class
 from picamera2 import Picamera2        # Raspberry Pi specific package for the camera, since Raspberry Pi OS 11
 from libcamera import controls
-import os.path, pathlib, json          # library for the json parameter parsing for the display
-from getmac import get_mac_address     # library to get the device MAC ddress
-from get_macs_AF import get_macs_AF    # import the get_macs_AF function
-macs_AF = get_macs_AF()                # mac addresses of AF bots are retrieved
 import time
 
 


### PR DESCRIPTION
Commit ac3a9e7fd261da840af291f55284d9e925bd90f7 removed the routine get_macs_AF, however the file was still being imported in the camera code.

Remove the broken imports and also other unreferenced imports in the 2 camera files.