### PR TITLE
Speed Optimize: Allow 180 degree spins and rotates

### DIFF
--- a/src/Cubotino_T.py
+++ b/src/Cubotino_T.py
@@ -3950,15 +3950,21 @@ def cube_facelets_permutation(cube_status, move_type, direction):
              18,19,20,21,22,23,24,25,26,42,39,36,43,40,37,44,41,38,35,34,33,32,31,30,29,28,27)
     
     elif move_type == 'S':       # case the robot move is a spin (complete cube rotation around vertical axis)
-        if direction == '1':     # case spin is CW
+        if direction == '0' or direction == '4':     # case spin is 180deg
+            ref=(8,7,6,5,4,3,2,1,0,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,\
+                 35,34,33,32,31,30,29,28,27,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26)
+        elif direction == '1':   # case spin is CW
             ref=(2,5,8,1,4,7,0,3,6,18,19,20,21,22,23,24,25,26,36,37,38,39,40,41,42,43,44,\
                  33,30,27,34,31,28,35,32,29,45,46,47,48,49,50,51,52,53,9,10,11,12,13,14,15,16,17)
-        elif direction == '3':      # case spin is CCW
+        elif direction == '3':   # case spin is CCW
             ref=(6,3,0,7,4,1,8,5,2,45,46,47,48,49,50,51,52,53,9,10,11,12,13,14,15,16,17,\
                  29,32,35,28,31,34,27,30,33,18,19,20,21,22,23,24,25,26,36,37,38,39,40,41,42,43,44)
-    
+   
     elif move_type == 'R':       # case the robot move is a rotation (lowest layer rotation versus mid and top ones) 
-        if direction == '1':     # case 1st layer rotation is CW
+        if direction == '0' or direction == '4':     # case 1st layer rotation is 180deg
+            ref=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,42,43,44,18,19,20,21,22,23,51,52,53,\
+                 35,34,33,32,31,30,29,28,27,36,37,38,39,40,41,15,16,17,45,46,47,48,49,50,24,25,26)
+        elif direction == '1':   # case 1st layer rotation is CW
             ref=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,24,25,26,18,19,20,21,22,23,42,43,44,\
                  33,30,27,34,31,28,35,32,29,36,37,38,39,40,41,51,52,53,45,46,47,48,49,50,15,16,17)
         elif direction == '3':   # case 1st layer rotation is CCW

--- a/src/Cubotino_T_moves.py
+++ b/src/Cubotino_T_moves.py
@@ -19,7 +19,8 @@
 #
 #
 # Possible moves with this robot
-# 1) Spins the complete cube ("S") laying on the bottom face: 1 means CW 90deg turns, while 3 means 90CCW turn
+# 1) Spins the complete cube ("S") laying on the bottom face:
+#	 0 means CW 180deg, 1 means CW 90deg turns, 3 means CCW 90deg turn, while 4 means CCW 180deg turn
 # 2) Flips the complete cube ("F") by "moving" the Front face to Bottom face: Only positive values are possible
 # 3) Rotates the bottom layer ("R") while costraining the 2nd and 3rd layer.
 # 4) The order of S, F has to be strictly followed
@@ -56,34 +57,37 @@ by knowing 5 faces, the 6th (B face) is also known ;-)
 
 # Global variable
 # Below dict has all the possible robot movements, related to the cube solver string
-moves_dict = {'U1':'F2R1S3', 'U2':'F2R1S3R1S3', 'U3':'F2S1R3',
-              'D1':'R1S3',   'D2':'R1S3R1S3',   'D3':'S1R3',
-              'F1':'F1R1S3', 'F2':'F1R1S3R1S3', 'F3':'F1S1R3',
-              'B1':'F3R1S3', 'B2':'F3R1S3R1S3', 'B3':'F3S1R3',
-              'L1':'S3F3R1', 'L2':'S3F3R1S3R1', 'L3':'S1F1R3',
-              'R1':'S3F1R1', 'R2':'S3F1R1S3R1', 'R3':'S1F3R3'}
+# Original moves with spins and rotates only 90 degrees
+# moves_dict = {'U1':'F2R1S3', 'U2':'F2R1S3R1S3', 'U3':'F2S1R3',
+              # 'D1':'R1S3',   'D2':'R1S3R1S3',   'D3':'S1R3',
+              # 'F1':'F1R1S3', 'F2':'F1R1S3R1S3', 'F3':'F1S1R3',
+              # 'B1':'F3R1S3', 'B2':'F3R1S3R1S3', 'B3':'F3S1R3',
+              # 'L1':'S3F3R1', 'L2':'S3F3R1S3R1', 'L3':'S1F1R3',
+              # 'R1':'S3F1R1', 'R2':'S3F1R1S3R1', 'R3':'S1F3R3'}
 
+# Move dictionary if the cube servo is at home
+moves_dict_home = {'U1':'F2R1', 'U2':'F2S3R0', 'U3':'F2S1R3',
+              'D1':'R1',   'D2':'S3R0',   'D3':'S1R3',
+              'F1':'F1R1', 'F2':'F1S3R0', 'F3':'F1S1R3',
+              'B1':'F3R1', 'B2':'F3S3R0', 'B3':'F3S1R3',
+              'L1':'S3F3R1', 'L2':'S3F3R0', 'L3':'S1F1R3',
+              'R1':'S3F1R1', 'R2':'S3F1R0', 'R3':'S1F3R3'}
 
-moves_dict_home = {'U1':'F2R1', 'U2':'F2R1S3R1', 'U3':'F2S1R3',
-              'D1':'R1',   'D2':'R1S3R1',   'D3':'S1R3',
-              'F1':'F1R1', 'F2':'F1R1S3R1', 'F3':'F1S1R3',
-              'B1':'F3R1', 'B2':'F3R1S3R1', 'B3':'F3S1R3',
-              'L1':'S3F3R1', 'L2':'S3F3R1S3R1', 'L3':'S1F1R3',
-              'R1':'S3F1R1', 'R2':'S3F1R1S3R1', 'R3':'S1F3R3'}
+# Move dictionary if the cube servo is at CW position
+moves_dict_cw = {'U1':'F2S3R1', 'U2':'F2R4', 'U3':'F2R3',
+              'D1':'S3R1',   'D2':'R4',   'D3':'R3',
+              'F1':'F1S3R1', 'F2':'F1R4', 'F3':'F1R3',
+              'B1':'F3S3R1', 'B2':'F3R4', 'B3':'F3R3',
+              'L1':'S3F3R1', 'L2':'S3F3S3R0', 'L3':'S3F3R3',
+              'R1':'S3F1R1', 'R2':'S3F1S3R0', 'R3':'S3F1R3'}
 
-moves_dict_cw = {'U1':'F2S3R1', 'U2':'F2S3S3R1R1', 'U3':'F2S3R3',
-              'D1':'S3R1',   'D2':'S3S3R1R1',   'D3':'S3R3',
-              'F1':'F1S3R1', 'F2':'F1S3S3R1R1', 'F3':'F1S3R3',
-              'B1':'F3S3R1', 'B2':'F3S3S3R1R1', 'B3':'F3S3R3',
-              'L1':'S3F3R1', 'L2':'S3F3S3R1R1', 'L3':'S3F3R3',
-              'R1':'S3F1R1', 'R2':'S3F1S3R1R1', 'R3':'S3F1R3'}
-
-moves_dict_ccw = {'U1':'F2R1', 'U2':'F2R1R1', 'U3':'F2S1R3',
-              'D1':'R1',   'D2':'R1R1',   'D3':'S1R3',
-              'F1':'F1R1', 'F2':'F1R1R1', 'F3':'F1S1R3',
-              'B1':'F3R1', 'B2':'F3R1R1', 'B3':'F3S1R3',
-              'L1':'S1F1R1', 'L2':'S1F1R1S3R1', 'L3':'S1F1R3',
-              'R1':'S1F3R1', 'R2':'S1F3R1S3R1', 'R3':'S1F3R3'}
+# Move dictionary if the cube servo is at CCW position
+moves_dict_ccw = {'U1':'F2R1', 'U2':'F2R0', 'U3':'F2S1R3',
+              'D1':'R1',   'D2':'R0',   'D3':'S1R3',
+              'F1':'F1R1', 'F2':'F1R0', 'F3':'F1S1R3',
+              'B1':'F3R1', 'B2':'F3R0', 'B3':'F3S1R3',
+              'L1':'S1F1R1', 'L2':'S1F1S3R0', 'L3':'S1F1R3',
+              'R1':'S1F3R1', 'R2':'S1F3S3R0', 'R3':'S1F3R3'}
 
 
 def starting_cube_orientation():
@@ -174,15 +178,18 @@ def cube_orient_update(movement):
         
         elif movement[i] == 'S':                   # case there is a cube spin on robot movements
             repeats=int(movement[i+1])             # retrieves how many spin
-            if repeats=='3':                       # case the spin is CCW
+            if repeats == 3:                       # case the spin is CCW
                 spinCCW_effect(h_faces,v_faces)    # re-order the cube orientation on the robot due to the CCW spin
-            else:                                  # case the spin is CW
-                for j in range(repeats):           # iterates over the amount of spin
-                    spinCW_effect(h_faces,v_faces) # re-order the cube orientation on the robot due to the CW spin             
-
-
-
-
+            elif repeats == 4:                     # case the spin is CCW 180deg
+                spinCCW_effect(h_faces,v_faces)    # re-order the cube orientation on the robot due to the CCW 180deg spin
+                spinCCW_effect(h_faces,v_faces)
+            elif repeats == 0:                     # case the spin is CW 180deg
+                spinCW_effect(h_faces,v_faces)     # re-order the cube orientation on the robot due to the CW 180deg spin
+                spinCW_effect(h_faces,v_faces)
+            elif repeats == 1:                     # case the spin is CW
+                spinCW_effect(h_faces,v_faces) # re-order the cube orientation on the robot due to the CW spin
+            else:
+                print('Error: Unknown move for cube orientation update')
 
 
 def adapt_move(move):
@@ -333,8 +340,6 @@ def optim_moves2(moves):
 
 
 
-
-
 def count_moves(moves):
     """Counts the total amount of robot movements."""
 
@@ -359,14 +364,18 @@ def get_new_cube_angle(initial_angle, sequence):
     new_angle = initial_angle
     for i in range(0,str_length,2):      # for loop of with steps = 2
         if sequence[i] == 'S' or sequence[i] == 'R':
-            if sequence[i+1] == '1':
+            if sequence[i+1] == '0':     # CW 180 deg spin
+                new_angle += 180
+            elif sequence[i+1] == '1':	 # CW 90 deg spin
                 new_angle += 90
-            elif sequence[i+1] == '3':
+            elif sequence[i+1] == '3':	 # CCW 90 deg spin
                 new_angle -= 90
-        if not -180 <= new_angle <= 180:
+            elif sequence[i+1] == '4':	 # CCW 180 deg spin
+                new_angle -= 180
+        if not -90 <= new_angle <= 90:	 # Check angle is coherent
             print("Angle error: %d" % new_angle)
 
-    print("Init Angle: %d, %s, New Angle:%d" % (initial_angle, sequence, new_angle))
+    # print("Init Angle: %d, %s, New Angle:%d" % (initial_angle, sequence, new_angle))
     return new_angle
 
 
@@ -380,12 +389,13 @@ def robot_required_moves(solution, solution_Text):
     
     solution=solution.strip()                     # eventual empty spaces are removed from the string
     solution=solution.replace(" ", "")            # eventual empty spaces are removed from the string
+    st_solution=solution
     starting_cube_orientation()                   # Cube orientation at the start, later updated after every cube movement on the robot
     robot={}                                      # empty dict to store all the robot moves
-    orig_moves=''
     moves=''                                      # empty string to store all the robot moves
     robot_tot_moves = 0                           # counter for all the robot movements
     angle = 0
+    adapted_solution = ''
     
     if solution_Text != 'Error':                  # case the solver did not return an error
         blocks = int(round(len(solution)/2,0))    # total amount of blocks of movements (i.e. U2R1L3 are 3 blocks: U2, R1 and L1)
@@ -395,27 +405,26 @@ def robot_required_moves(solution, solution_Text):
             move=solution[:2]                     # move to be applied on this block, according to the solver
             solution=solution[2:]                 # remaining movements from the solver are updated
             adapted_move=adapt_move(move)         # the move from solver is adapted considering the real cube orientation
-            robot_seq=moves_dict_home[adapted_move]    # robot movement sequence is retrieved
-            orig_moves+=robot_seq
+            adapted_solution+=adapted_move
             if angle == 0:
                 robot_seq=moves_dict_home[adapted_move]    # robot movement sequence is retrieved
             elif angle == -90:
                 robot_seq=moves_dict_ccw[adapted_move]    # robot movement sequence is retrieved
             elif angle == 90:
                 robot_seq=moves_dict_cw[adapted_move]    # robot movement sequence is retrieved
+            else:
+                print("Error converting solution to moves")
             angle = get_new_cube_angle(angle, robot_seq)
             robot[block]=robot_seq                # robot movements dict is updated
             moves+=robot_seq                      # robot movements string is updated
             cube_orient_update(robot_seq)         # cube orientation updated after the robot move from this block
-                           
-        orig_moves = optim_moves1(orig_moves)               # removes eventual unnecessary moves (that would cancel each other out)
-        orig_moves = optim_moves2(orig_moves)               # removes eventual unnecessary flips
-        robot_tot_moves = count_moves(orig_moves)      # counter for the total amount of robot movements
-        print("Orig: %s :%d" %(orig_moves,robot_tot_moves))
+        #print('Initial: %s' % st_solution)
+        #print('Adapted: %s' % adapted_solution)
+        #print('Orig: %s :%d' %(moves,robot_tot_moves))
         moves = optim_moves1(moves)               # removes eventual unnecessary moves (that would cancel each other out)
         moves = optim_moves2(moves)               # removes eventual unnecessary flips
         robot_tot_moves = count_moves(moves)      # counter for the total amount of robot movements
-        print("New: %s :%d" %(moves,robot_tot_moves))
+        #print('New : %s :%d' %(moves,robot_tot_moves))
     return robot, moves, robot_tot_moves  # returns a dict with all the robot moves, string with all the moves and total robot movements
     # NOTE: dict has all the theorethical robot movements, the string might differ due to optimization
 

--- a/src/Cubotino_T_moves.py
+++ b/src/Cubotino_T_moves.py
@@ -66,28 +66,28 @@ by knowing 5 faces, the 6th (B face) is also known ;-)
               # 'R1':'S3F1R1', 'R2':'S3F1R1S3R1', 'R3':'S1F3R3'}
 
 # Move dictionary if the cube servo is at home
-moves_dict_home = {'U1':'F2R1', 'U2':'F2S3R0', 'U3':'F2S1R3',
-              'D1':'R1',   'D2':'S3R0',   'D3':'S1R3',
-              'F1':'F1R1', 'F2':'F1S3R0', 'F3':'F1S1R3',
-              'B1':'F3R1', 'B2':'F3S3R0', 'B3':'F3S1R3',
-              'L1':'S3F3R1', 'L2':'S3F3R0', 'L3':'S1F1R3',
-              'R1':'S3F1R1', 'R2':'S3F1R0', 'R3':'S1F3R3'}
+moves_dict_home = {'U1':'F2R1',     'U2':'F2S3R0',   'U3':'F2R3',
+                   'D1':'R1',       'D2':'S3R0',     'D3':'R3',
+                   'F1':'F1R1',     'F2':'F1S3R0',   'F3':'F1R3',
+                   'B1':'F3R1',     'B2':'F3S3R0',   'B3':'F3R3',
+                   'L1':'S1F1S3R1', 'L2':'S1F1S4R0', 'L3':'S1F1R3',
+                   'R1':'S3F1R1',   'R2':'S3F1R0',   'R3':'S3F1S1R3'}
 
 # Move dictionary if the cube servo is at CW position
-moves_dict_cw = {'U1':'F2S3R1', 'U2':'F2R4', 'U3':'F2R3',
-              'D1':'S3R1',   'D2':'R4',   'D3':'R3',
-              'F1':'F1S3R1', 'F2':'F1R4', 'F3':'F1R3',
-              'B1':'F3S3R1', 'B2':'F3R4', 'B3':'F3R3',
-              'L1':'S3F3R1', 'L2':'S3F3S3R0', 'L3':'S3F3R3',
-              'R1':'S3F1R1', 'R2':'S3F1S3R0', 'R3':'S3F1R3'}
+moves_dict_cw =   {'U1':'F2S3R1',   'U2':'F2R4',     'U3':'F2R3',
+                   'D1':'S3R1',     'D2':'R4',       'D3':'R3',
+                   'F1':'F1S3R1',   'F2':'F1R4',     'F3':'F1R3',
+                   'B1':'F3S3R1',   'B2':'F3R4',     'B3':'F3R3',
+                   'L1':'S3F3R1',   'L2':'S3F3S3R0', 'L3':'S3F3R3',
+                   'R1':'S3F1R1',   'R2':'S3F1S3R0', 'R3':'S3F1R3'}
 
 # Move dictionary if the cube servo is at CCW position
-moves_dict_ccw = {'U1':'F2R1', 'U2':'F2R0', 'U3':'F2S1R3',
-              'D1':'R1',   'D2':'R0',   'D3':'S1R3',
-              'F1':'F1R1', 'F2':'F1R0', 'F3':'F1S1R3',
-              'B1':'F3R1', 'B2':'F3R0', 'B3':'F3S1R3',
-              'L1':'S1F1R1', 'L2':'S1F1S3R0', 'L3':'S1F1R3',
-              'R1':'S1F3R1', 'R2':'S1F3S3R0', 'R3':'S1F3R3'}
+moves_dict_ccw =  {'U1':'F2R1',     'U2':'F2R0',     'U3':'F2S1R3',
+                   'D1':'R1',       'D2':'R0',       'D3':'S1R3',
+                   'F1':'F1R1',     'F2':'F1R0',     'F3':'F1S1R3',
+                   'B1':'F3R1',     'B2':'F3R0',     'B3':'F3S1R3',
+                   'L1':'S1F1R1',   'L2':'S1F1S3R0', 'L3':'S1F1R3',
+                   'R1':'S1F3R1',   'R2':'S1F3S3R0', 'R3':'S1F3R3'}
 
 
 def starting_cube_orientation():
@@ -360,6 +360,8 @@ def count_moves(moves):
 
 def get_new_cube_angle(initial_angle, sequence):
 
+    global robot_stop
+
     str_length=len(sequence)                # length of the robot move string
     new_angle = initial_angle
     for i in range(0,str_length,2):      # for loop of with steps = 2
@@ -373,7 +375,8 @@ def get_new_cube_angle(initial_angle, sequence):
             elif sequence[i+1] == '4':	 # CCW 180 deg spin
                 new_angle -= 180
         if not -90 <= new_angle <= 90:	 # Check angle is coherent
-            print("Angle error: %d" % new_angle)
+            print(f'Sequence {sequence} creates a servo angle error {new_angle}')
+            robot_stop = True
 
     # print("Init Angle: %d, %s, New Angle:%d" % (initial_angle, sequence, new_angle))
     return new_angle
@@ -439,16 +442,19 @@ if __name__ == "__main__":
         Afterward all the strings are combined in a single string, for the Cubotino_servo.py module to control the servos."""  
     
     
-#93-87    solution = 'U2 L1 R1 D2 B2 R1 D2 B2 D2 L3 B3 R3 F2 D3 L1 U2 F2 D3 B3 D1' # this cube solution allows type 1 optimization (at least 2 Spins removal)
+#     solution = 'U2 L1 R1 D2 B2 R1 D2 B2 D2 L3 B3 R3 F2 D3 L1 U2 F2 D3 B3 D1' # this cube solution allows type 1 optimization (at least 2 Spins removal)
     solution = 'U2 D2 R2 L2 F2 B2'  # this cube solution allows type 2 optimization (2 flips removal)
-#74-83    solution = 'R2 L1 D3 F2 L2 B1 L1 U3 R1 F1 L2 D3 F2 D1 F2 B2 D2' # this cube solution allows type 1 optimization (at least 2 Spins removal)
-#89-88    solution = 'L1 D2 L1 D2 R2 F2 D2 R1 F3 R1 U1 R2 B3 L3 D1 R1 D2 B2 F3' # this cube solution has only 1st criteria for type2 optimization
-#49-44    solution = 'F3 U1 D2 R2 L2 U2 D2 R1 L2' # this cube solution has only only 1st criteria for type2 optimization
+#     solution = 'R2 L1 D3 F2 L2 B1 L1 U3 R1 F1 L2 D3 F2 D1 F2 B2 D2' # this cube solution allows type 1 optimization (at least 2 Spins removal)
+#     solution = 'L1 D2 L1 D2 R2 F2 D2 R1 F3 R1 U1 R2 B3 L3 D1 R1 D2 B2 F3' # this cube solution has only 1st criteria for type2 optimization
+#     solution = 'F3 U1 D2 R2 L2 U2 D2 R1 L2' # this cube solution has only only 1st criteria for type2 optimization
 
     print()
     print("Example of robot movements for solver solution: ", solution)
     print("Robot moves are noted with the 3 letters S, F, R (Spin, Flip, Rotate) followed by a number")
-    print("Number '1' for S ans R identifies CW rotation, by loking to the bottom face, while number '3' stands for CCW")
+    print("Number '0' for S and R identifies 180deg CW rotation, by looking to the bottom face,")
+    print("       '1' for S and R identifies 90deg CW rotation")
+    print("       '3' for S and R identifies 90deg CCW rotation")
+    print("       '4' for S and R identifies 180deg CCW rotation")
     print("Example 'F1R1S3' means: 1x cube Flip, 1x (90deg) CW rotation of the 1st (bottom) layer, 1x (90deg) CCW cube Spin")
     print()
     

--- a/src/Cubotino_T_servos.py
+++ b/src/Cubotino_T_servos.py
@@ -650,12 +650,12 @@ def spin_out(direction, target=0, release=0, timer1=0, test=False):
     if not b_servo_operable and t_top_cover=='read':
         flip_to_open()
 
-    if direction[-1] == '2':
-        direction=direction[0:-1]
-        number = 2.1
-        b_servo_home=True  ## Needed to trick routine
+    if direction[-1] == '2':                         # Full 180deg movement requested
+        direction=direction[0:-1]                    # Get just the direction
+        number = 2.1                                 # 180deg movement is time adjustment to b_spin_time
+        b_servo_home=True                            # Routine checks for home position
     else:
-        number = 1.0
+        number = 1.0                                 # No move time adjustment for 90deg moves
 
     if not stop_servos:                              # case there is not a stop request for servos
         if b_servo_operable==True:                   # variable to block/allow bottom servo operation
@@ -726,12 +726,11 @@ def spin_home():
 
 
 
-
-# def spin(direction):
-    # """ Spins the cube during the cube detection phase"""
+def spin(direction):
+    """ Spins the cube during the cube detection phase"""
     
-    # spin_out(direction)  # calls the spin_out function
-    # spin_home()          # calls the spin home function
+    spin_out(direction)  # calls the spin_out function
+    spin_home()          # calls the spin home function
 
 
 
@@ -745,31 +744,31 @@ def rotate_out(direction):
     
     global t_top_cover, b_servo_operable, b_servo_stopped, b_servo_home, b_servo_CW_pos, b_servo_CCW_pos
     
-    if direction[-1] == '2':
-        direction=direction[0:-1]
-        number = 2.1
-        b_servo_home=True  ## Needed to trick routine
+    if direction[-1] == '2':                         # Full 180deg movement requested
+        direction=direction[0:-1]                    # Get just the direction
+        number = 2.1                                 # 180deg movement is time adjustment to b_spin_time
+        b_servo_home=True                            # Routine checks for home position
     else:
-        number = 1.0
+        number = 1.0                                 # No move time adjustment for 90deg moves
 
     if not stop_servos:                                   # case there is not a stop request for servos
         if t_top_cover!='close':                          # case the top cover is not in close position
             close_cover()                                 # top cover is lowered in close position
-        
+
         if b_servo_operable==True:                        # variable to block/allow bottom servo operation
             if b_servo_home==True:                        # boolean of bottom servo at home=
                 b_servo_stopped=False                     # boolean of bottom servo at location the lifter can be operated
-                
+
                 if direction=='CCW':                      # case the set direction is CCW
                     b_servo.value = b_servo_CCW           # bottom servo moves to the most CCW position
-                    time.sleep(b_rotate_time*number)             # time for the bottom servo to reach the most CCW position
+                    time.sleep(b_rotate_time*number)      # time for the bottom servo to reach the most CCW position
                     b_servo.value = b_servo_CCW_rel       # bottom servo moves slightly to release the tensions
                     time.sleep(b_rel_time)                # time for the servo to release the tensions
                     b_servo_CCW_pos=True                  # boolean of bottom servo at full CCW position
                     b_servo_CW_pos=False
                 elif direction=='CW':                     # case the set direction is CW
                     b_servo.value = b_servo_CW            # bottom servo moves to the most CCW position
-                    time.sleep(b_rotate_time*number)             # time for the bottom servo to reach the most CCW position
+                    time.sleep(b_rotate_time*number)      # time for the bottom servo to reach the most CCW position
                     b_servo.value = b_servo_CW_rel        # bottom servo moves slightly to release the tensions
                     time.sleep(b_rel_time)                # time for the servo to release the tensions
                     b_servo_CW_pos=True                   # boolean of bottom servo at full CW position
@@ -1092,18 +1091,18 @@ def servo_solve_cube(moves, scrambling=False, print_out=s_debug, test=False):
             if print_out:                          # case the print_out variable is set true
                 print(f'To do S{direction} {curpos}')       # for print_out
 
-            if direction==4:                       # case the direction is CCW
-                set_dir='CCW2'                      # CCW directio is assigned to the variable
-            elif direction==3:                       # case the direction is CCW
-                set_dir='CCW'                      # CCW directio is assigned to the variable
-            elif direction==0:                       # case the direction is CCW
-                set_dir='CW2'                      # CCW directio is assigned to the variable
-            else:                                  # case the direction is CW
-                set_dir='CW'                       # CW directio is assigned to the variable
+            if direction==4:                       # case the direction is 180 CCW
+                set_dir='CCW2'                     # CCW2 direction is assigned to the variable
+            elif direction==3:                     # case the direction is 90 CCW
+                set_dir='CCW'                      # CCW direction is assigned to the variable
+            elif direction==0:                     # case the direction is 180 CW
+                set_dir='CW2'                      # CW2 direction is assigned to the variable
+            else:                                  # case the direction is 90 CW
+                set_dir='CW'                       # CW direction is assigned to the variable
             
             if b_servo_home==True:                 # case bottom servo is at home
                 spin_out(set_dir)                  # call to function to spin the full cube to full CW or CCW
-            elif set_dir[-1] == '2':
+            elif set_dir[-1] == '2':               # If the call is for 180deg spin
                 spin_out(set_dir)                  # call to function to spin the full cube to full CW or CCW
             else:                                  # case the bottom servo is at full CW or CCW position
                 spin_home()                        # call to function to spin the full cube toward home position
@@ -1114,25 +1113,21 @@ def servo_solve_cube(moves, scrambling=False, print_out=s_debug, test=False):
             if print_out:                          # case the print_out variable is set true
                 print(f'To do R{direction} {curpos}')       # for print_out
 
-            if direction==4:                       # case the direction is CCW
-                set_dir='CCW2'                      # CCW directio is assigned to the variable
-            elif direction==3:                       # case the direction is CCW
-                set_dir='CCW'                      # CCW directio is assigned to the variable
-            elif direction==0:                       # case the direction is CCW
-                set_dir='CW2'                      # CCW directio is assigned to the variable
-            else:                                  # case the direction is CW
-                set_dir='CW'                       # CW directio is assigned to the variable
+            if direction==4:                       # case the direction is 180 CCW
+                set_dir='CCW2'                     # CCW2 direction is assigned to the variable
+            elif direction==3:                     # case the direction is 90 CCW
+                set_dir='CCW'                      # CCW direction is assigned to the variable
+            elif direction==0:                     # case the direction is 180 CW
+                set_dir='CW2'                      # CW2 direction is assigned to the variable
+            else:                                  # case the direction is 90 CW
+                set_dir='CW'                       # CW direction is assigned to the variable
             
             if b_servo_home==True:                 # case bottom servo is at home
                 rotate_out(set_dir)                # call to function to rotate cube 1st layer on the set direction, moving out from home              
-            elif set_dir[-1] == '2':
+            elif set_dir[-1] == '2':               # If the call is for 180deg spin
                 rotate_out(set_dir)                # call to function to spin the full cube to full CW or CCW
-            elif b_servo_CW_pos==True:             # case the bottom servo is at full CW position
-                if set_dir=='CCW':                 # case the set direction is CCW
-                    rotate_home(set_dir)           # call to function to spin the full cube toward home position
-            elif b_servo_CCW_pos==True:            # case the bottom servo is at full CCW position
-                if set_dir=='CW':                  # case the set direction is CW
-                    rotate_home(set_dir)           # call to function to spin the full cube toward home position
+            else:                                  # case the bottom servo needs to rotate home
+                rotate_home(set_dir)               # call to function to spin the full cube toward home position
     
     if stop_servos:                                # case there is a stop request for servos 
         if print_out:                              # case the print_out variable is set true
@@ -1505,9 +1500,9 @@ def test_set_of_movements():
     
     print('\nDemonstration of the robot servos current settings, by solving a predefined scrambled cube')   
     print('Press the touch button to interrupt the test')
-
-    movements= 'F1R1S3R1F3S3R1F1S4R0F3S4R0S3F1S3R0S3F3R1F1S4R0F1S3R1F3S4R0F1S4R0S3F1R3F1S1R3S1F1R3F2S1R3S1F1R3S1F1R3S1F3R3F3R1F2R1S3R1F1S3R1F2S4R0'
-#    movements += 'F1R3S1F1R3F1S1R3S3F1R1S3R1F3S1R3F1R1S3S3F3R1S3R1F3R1S3R1S3F1S1R3S1F3R3F1R1S3'
+        
+    movements= 'F2R1S3R1S3S3F1R1F2R1S3S3F1R1S3R1F3R1S3R1S3S3F3R1S3F1R1S3R1F3R1S3R1S3F3R1S3R1'
+    movements += 'F1R3S1F1R3F1S1R3S3F1R1S3R1F3S1R3F1R1S3S3F3R1S3R1F3R1S3R1S3F1S1R3S1F3R3F1R1S3'
     # to complete the moves of this string CUBOTino takes 1m:8secs (18/04/2022)
     
     

--- a/src/Cubotino_T_servos.py
+++ b/src/Cubotino_T_servos.py
@@ -649,7 +649,14 @@ def spin_out(direction, target=0, release=0, timer1=0, test=False):
            
     if not b_servo_operable and t_top_cover=='read':
         flip_to_open()
-        
+
+    if direction[-1] == '2':
+        direction=direction[0:-1]
+        number = 2.1
+        b_servo_home=True  ## Needed to trick routine
+    else:
+        number = 1.0
+
     if not stop_servos:                              # case there is not a stop request for servos
         if b_servo_operable==True:                   # variable to block/allow bottom servo operation
             if b_servo_home==True or test:           # boolean of bottom servo at home
@@ -665,9 +672,9 @@ def spin_out(direction, target=0, release=0, timer1=0, test=False):
                             b_servo.value = target + release   # bottom servo moves back of releave value
                     else:                            # case the variable test is set False
                         b_servo.value = b_servo_CCW_rel  # bottom servo moves to almost the max CCW position
-                        time.sleep(b_spin_time)      # time for the bottom servo to reach the most CCW position
+                        time.sleep(b_spin_time*number)      # time for the bottom servo to reach the most CCW position
                         b_servo_CCW_pos=True         # boolean of bottom servo at full CCW position
-                
+                        b_servo_CW_pos=False                
                 elif direction=='CW':                # case the set direction is CW
                     if test:                         # case the variable test is set True
                         b_servo.value = target       # bottom servo moves to the most CW position 
@@ -676,9 +683,9 @@ def spin_out(direction, target=0, release=0, timer1=0, test=False):
                             b_servo.value = target - release   # bottom servo moves back of releave value
                     else:                            # case the variable test is set False
                         b_servo.value = b_servo_CW_rel   # bottom servo moves to almost the max CW position 
-                        time.sleep(b_spin_time)      # time for the bottom servo to reach the most CW position
+                        time.sleep(b_spin_time*number)      # time for the bottom servo to reach the most CW position
                         b_servo_CW_pos=True          # boolean of bottom servo at full CW position
-                
+                        b_servo_CCW_pos=False                
                 b_servo_stopped=True                 # boolean of bottom servo at location the lifter can be operated
                 b_servo_home=False                   # boolean of bottom servo at home
                 b_servo_stopped=True                 # boolean of bottom servo at location the lifter can be operated
@@ -720,11 +727,11 @@ def spin_home():
 
 
 
-def spin(direction):
-    """ Spins the cube during the cube detection phase"""
+# def spin(direction):
+    # """ Spins the cube during the cube detection phase"""
     
-    spin_out(direction)  # calls the spin_out function
-    spin_home()          # calls the spin home function
+    # spin_out(direction)  # calls the spin_out function
+    # spin_home()          # calls the spin home function
 
 
 
@@ -738,6 +745,13 @@ def rotate_out(direction):
     
     global t_top_cover, b_servo_operable, b_servo_stopped, b_servo_home, b_servo_CW_pos, b_servo_CCW_pos
     
+    if direction[-1] == '2':
+        direction=direction[0:-1]
+        number = 2.1
+        b_servo_home=True  ## Needed to trick routine
+    else:
+        number = 1.0
+
     if not stop_servos:                                   # case there is not a stop request for servos
         if t_top_cover!='close':                          # case the top cover is not in close position
             close_cover()                                 # top cover is lowered in close position
@@ -748,18 +762,19 @@ def rotate_out(direction):
                 
                 if direction=='CCW':                      # case the set direction is CCW
                     b_servo.value = b_servo_CCW           # bottom servo moves to the most CCW position
-                    time.sleep(b_rotate_time)             # time for the bottom servo to reach the most CCW position
+                    time.sleep(b_rotate_time*number)             # time for the bottom servo to reach the most CCW position
                     b_servo.value = b_servo_CCW_rel       # bottom servo moves slightly to release the tensions
                     time.sleep(b_rel_time)                # time for the servo to release the tensions
                     b_servo_CCW_pos=True                  # boolean of bottom servo at full CCW position
-                    
+                    b_servo_CW_pos=False
                 elif direction=='CW':                     # case the set direction is CW
                     b_servo.value = b_servo_CW            # bottom servo moves to the most CCW position
-                    time.sleep(b_rotate_time)             # time for the bottom servo to reach the most CCW position
+                    time.sleep(b_rotate_time*number)             # time for the bottom servo to reach the most CCW position
                     b_servo.value = b_servo_CW_rel        # bottom servo moves slightly to release the tensions
                     time.sleep(b_rel_time)                # time for the servo to release the tensions
                     b_servo_CW_pos=True                   # boolean of bottom servo at full CW position
-                    
+                    b_servo_CCW_pos=False
+
                 b_servo_stopped=True                      # boolean of bottom servo at location the lifter can be operated
                 b_servo_home=False                        # boolean of bottom servo at home
                 
@@ -873,15 +888,25 @@ def check_moves(moves, print_out=s_debug):
                 servo_angle+=90                           # positive 90deg angle are added to the angle counter
                 tot_moves+=1                              # counter is increased
 
+        elif moves[i]=='0':                               # case direction is CW 
+            if moves[i-1] == 'R' or moves[i-1] == 'S':    # case the direction refers to cube spin or layer rotation
+                servo_angle+=180                           # negative 90deg angle are subtracted from the angle counter
+                tot_moves+=1                              # counter is increased
+
         elif moves[i]=='3':                               # case direction is CW 
             if moves[i-1] == 'R' or moves[i-1] == 'S':    # case the direction refers to cube spin or layer rotation
                 servo_angle-=90                           # negative 90deg angle are subtracted from the angle counter
                 tot_moves+=1                              # counter is increased
 
+        elif moves[i]=='4':                               # case direction is CW 
+            if moves[i-1] == 'R' or moves[i-1] == 'S':    # case the direction refers to cube spin or layer rotation
+                servo_angle-=180                           # negative 90deg angle are subtracted from the angle counter
+                tot_moves+=1                              # counter is increased
+
         elif moves[i]=='F':                               # case there is a flip on the move string
             tot_moves+=int(moves[i+1])                    # counter is increased
         
-        if servo_angle<-90 or servo_angle>180:            # case the angle counter is out of range
+        if servo_angle<-90 or servo_angle>90:            # case the angle counter is out of range
             if print_out:                                 # case the print_out variable is set true
                 print(f'Servo_angle out of range at string pos:{i}')  # info are printed
             servo_angle_ok=False                          # bolean of results is updated
@@ -982,9 +1007,8 @@ def servo_solve_cube(moves, scrambling=False, print_out=s_debug, test=False):
         This is substantially the main function."""
     
     global t_top_cover, b_servo_operable, b_servo_stopped, b_servo_home
-    
+
     start_time=time.time()                         # start time is assigned
-    
     # the received string is analyzed if compatible with servo rotation contraints, and amount of movements
     servo_angle_ok, tot_moves, remaining_moves = check_moves(moves, print_out=s_debug)
     
@@ -1019,6 +1043,22 @@ def servo_solve_cube(moves, scrambling=False, print_out=s_debug, test=False):
             # calls the display progress bar function. SCRAMBLING is displayed when that fuction is used
             s_disp.display_progress_bar(remaining_moves[i], scrambling)
         
+        curpos = ''
+        if b_servo_CCW_pos:
+            curpos+='-'
+        else:
+            curpos+=' '
+
+        if b_servo_home:
+            curpos+='H'
+        else:
+            curpos+=' '
+
+        if b_servo_CW_pos:
+            curpos+='+'
+        else:
+            curpos+=' '
+
         if moves[i]=='F':                          # case there is a flip on the move string
             flips=int(moves[i+1])                  # number of flips
             if print_out:                          # case the print_out variable is set true
@@ -1050,16 +1090,21 @@ def servo_solve_cube(moves, scrambling=False, print_out=s_debug, test=False):
         elif moves[i]=='S':                        # case there is a cube spin on the move string
             direction=int(moves[i+1])              # rotation direction is retrived
             if print_out:                          # case the print_out variable is set true
-                print(f'To do S{direction}')       # for print_out
+                print(f'To do S{direction} {curpos}')       # for print_out
 
-            if direction==3:                       # case the direction is CCW
+            if direction==4:                       # case the direction is CCW
+                set_dir='CCW2'                      # CCW directio is assigned to the variable
+            elif direction==3:                       # case the direction is CCW
                 set_dir='CCW'                      # CCW directio is assigned to the variable
+            elif direction==0:                       # case the direction is CCW
+                set_dir='CW2'                      # CCW directio is assigned to the variable
             else:                                  # case the direction is CW
                 set_dir='CW'                       # CW directio is assigned to the variable
             
             if b_servo_home==True:                 # case bottom servo is at home
                 spin_out(set_dir)                  # call to function to spin the full cube to full CW or CCW
-            
+            elif set_dir[-1] == '2':
+                spin_out(set_dir)                  # call to function to spin the full cube to full CW or CCW
             else:                                  # case the bottom servo is at full CW or CCW position
                 spin_home()                        # call to function to spin the full cube toward home position
 
@@ -1067,20 +1112,24 @@ def servo_solve_cube(moves, scrambling=False, print_out=s_debug, test=False):
         elif moves[i]=='R':                        # case there is a cube 1st layer rotation
             direction=int(moves[i+1])              # rotation direction is retrived   
             if print_out:                          # case the print_out variable is set true
-                print(f'To do R{direction}')       # for print_out
+                print(f'To do R{direction} {curpos}')       # for print_out
 
-            if direction==3:                       # case the direction is CCW
+            if direction==4:                       # case the direction is CCW
+                set_dir='CCW2'                      # CCW directio is assigned to the variable
+            elif direction==3:                       # case the direction is CCW
                 set_dir='CCW'                      # CCW directio is assigned to the variable
+            elif direction==0:                       # case the direction is CCW
+                set_dir='CW2'                      # CCW directio is assigned to the variable
             else:                                  # case the direction is CW
                 set_dir='CW'                       # CW directio is assigned to the variable
             
             if b_servo_home==True:                 # case bottom servo is at home
                 rotate_out(set_dir)                # call to function to rotate cube 1st layer on the set direction, moving out from home              
-            
+            elif set_dir[-1] == '2':
+                rotate_out(set_dir)                # call to function to spin the full cube to full CW or CCW
             elif b_servo_CW_pos==True:             # case the bottom servo is at full CW position
                 if set_dir=='CCW':                 # case the set direction is CCW
                     rotate_home(set_dir)           # call to function to spin the full cube toward home position
-                
             elif b_servo_CCW_pos==True:            # case the bottom servo is at full CCW position
                 if set_dir=='CW':                  # case the set direction is CW
                     rotate_home(set_dir)           # call to function to spin the full cube toward home position
@@ -1456,9 +1505,9 @@ def test_set_of_movements():
     
     print('\nDemonstration of the robot servos current settings, by solving a predefined scrambled cube')   
     print('Press the touch button to interrupt the test')
-        
-    movements= 'F2R1S3R1S3S3F1R1F2R1S3S3F1R1S3R1F3R1S3R1S3S3F3R1S3F1R1S3R1F3R1S3R1S3F3R1S3R1'
-    movements += 'F1R3S1F1R3F1S1R3S3F1R1S3R1F3S1R3F1R1S3S3F3R1S3R1F3R1S3R1S3F1S1R3S1F3R3F1R1S3'
+
+    movements= 'F1R1S3R1F3S3R1F1S4R0F3S4R0S3F1S3R0S3F3R1F1S4R0F1S3R1F3S4R0F1S4R0S3F1R3F1S1R3S1F1R3F2S1R3S1F1R3S1F1R3S1F3R3F3R1F2R1S3R1F1S3R1F2S4R0'
+#    movements += 'F1R3S1F1R3F1S1R3S3F1R1S3R1F3S1R3F1R1S3S3F3R1S3R1F3R1S3R1S3F1S1R3S1F3R3F1R1S3'
     # to complete the moves of this string CUBOTino takes 1m:8secs (18/04/2022)
     
     


### PR DESCRIPTION
I noticed that running many solves there were a lot of moves that were moving 180 degrees by a series of 90 degree motions.  You already had the logic to rotate the cube/solution faces any direction based on how it was sitting. So why not figure out moves from any spot of the robot mechanics. So I added 

1) The ability to rotate 180 degrees CW or CCW while spinning or rotating.
2) Added and optimized the move dictionaries.  There are different dictionary moves depending on what angle the cube holder servo is currently sitting.  When writing the new moves, I chose to optimize spins over flipping.

From my testing, This reduces moves by about 15-20  (180 degree moves are counted as 1)  but the big win is 10-20 second faster solves.  I left your original move dictionary in for reference.   Please test it out.
